### PR TITLE
WIP: Prevent variable reference error

### DIFF
--- a/stabi_booker.php
+++ b/stabi_booker.php
@@ -20,7 +20,8 @@ function new_matching_slot_IDs($source_landing_page, $config_only_mornings) {
     $matching_IDs = array();
 
     // select raw HTML string of each bookable slot
-    $relevant_part_source_landing_page = end(explode('rel="">Allgemeiner Lesesaal - Haus Unter den Linden</a></h3>', $source_landing_page));
+    $allg_lesesaal = explode('rel="">Allgemeiner Lesesaal - Haus Unter den Linden</a></h3>', $source_landing_page);
+    $relevant_part_source_landing_page = end($allg_lesesaal);
     $relevant_part_source_landing_page = explode('rel="">Zeitungslesesaal - Haus Unter den Linden</a></h3>', $relevant_part_source_landing_page);
     $relevant_part_source_landing_page = $relevant_part_source_landing_page[0];
 


### PR DESCRIPTION
Using php in version 8.0.11 I got this error:

```
PHP Notice:  Only variables should be passed by reference in /home/user/git/stabi_booker/stabi_booker.php on line 23
```

According to [this](https://stackoverflow.com/questions/4636166/only-variables-should-be-passed-by-reference#4636183) a simple solution is to copy to variable first. This fix is applied in this PR.